### PR TITLE
Update numpy 2.0.0

### DIFF
--- a/dataprofiler/labelers/base_data_labeler.py
+++ b/dataprofiler/labelers/base_data_labeler.py
@@ -25,7 +25,12 @@ class BaseDataLabeler:
 
     _default_model_loc: str = None  # type: ignore
 
-    def __init__(self, dirpath: str = None, load_options: dict = None) -> None:
+    def __init__(
+        self,
+        dirpath: str = None,
+        load_options: dict = None,
+        force_construct_model: bool = False,
+    ) -> None:
         """
         Initialize DataLabeler class.
 
@@ -39,6 +44,7 @@ class BaseDataLabeler:
             )
         # Example: self._model is an instance of BaseModel
         self._model: BaseModel = None  # type: ignore
+        self.force_construct_model = force_construct_model
 
         # Example: self._preprocessor and self._postprocessor are instances of
         # DataProcessing
@@ -535,7 +541,11 @@ class BaseDataLabeler:
                 "and could not be found as a registered model "
                 "class in BaseModel.".format(str(model_class))
             )
-        self.set_model(model_class.load_from_disk(dirpath))
+
+        model = model_class.load_from_disk(dirpath)
+        if self.force_construct_model:
+            model._construct_model()
+        self.set_model(model)
 
     def _load_preprocessor(
         self,

--- a/dataprofiler/labelers/char_load_tf_model.py
+++ b/dataprofiler/labelers/char_load_tf_model.py
@@ -262,7 +262,17 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
 
         # Compile the model w/ metrics
         softmax_output_layer_name = self._model.output_names[0]
-        losses = {softmax_output_layer_name: "categorical_crossentropy"}
+        all_outputs = self._model.output_names
+
+        losses = {
+            softmax_output_layer_name: "categorical_crossentropy",
+            all_outputs[1]: "mean_squared_error",
+        }
+
+        loss_weights = {
+            softmax_output_layer_name: 1.0,
+            all_outputs[1]: 0.0,
+        }
 
         # use f1 score metric
         f1_score_training = labeler_utils.F1Score(
@@ -276,7 +286,9 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
             ]
         }
 
-        self._model.compile(loss=losses, optimizer="adam", metrics=metrics)
+        self._model.compile(
+            loss=losses, loss_weights=loss_weights, optimizer="adam", metrics=metrics
+        )
 
         self._epoch_id = 0
         self._model_num_labels = num_labels
@@ -316,7 +328,17 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
 
         # Compile the model
         softmax_output_layer_name = self._model.output_names[0]
-        losses = {softmax_output_layer_name: "categorical_crossentropy"}
+        all_outputs = self._model.output_names
+
+        losses = {
+            softmax_output_layer_name: "categorical_crossentropy",
+            all_outputs[1]: "mean_squared_error",
+        }
+
+        loss_weights = {
+            softmax_output_layer_name: 1.0,
+            all_outputs[1]: 0.0,
+        }
 
         # use f1 score metric
         f1_score_training = labeler_utils.F1Score(
@@ -330,7 +352,9 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
             ]
         }
 
-        self._model.compile(loss=losses, optimizer="adam", metrics=metrics)
+        self._model.compile(
+            loss=losses, loss_weights=loss_weights, optimizer="adam", metrics=metrics
+        )
 
         self._epoch_id = 0
         self._model_num_labels = num_labels
@@ -381,19 +405,24 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
         f1_report: dict = {}
 
         self._model.reset_metrics()
-        softmax_output_layer_name = self._model.output_names[0]
 
         start_time = time.time()
         batch_id = 0
         for x_train, y_train in train_data:
-            model_results = self._model.train_on_batch(
-                x_train, {softmax_output_layer_name: y_train}
-            )
+
+            dummy = np.zeros((y_train.shape[0], y_train.shape[1]), dtype=y_train.dtype)
+
+            model_results = self._model.train_on_batch(x_train, [y_train, dummy])
             sys.stdout.flush()
             if verbose:
+                loss, acc, f1_score = (
+                    model_results[1],
+                    model_results[2],
+                    model_results[3],
+                )
                 sys.stdout.write(
-                    "\rEPOCH %d, batch_id %d: loss: %f - acc: %f - "
-                    "f1_score %f" % (self._epoch_id, batch_id, *model_results[1:])
+                    f"\rEPOCH {self._epoch_id}, batch {batch_id}: "
+                    f"loss {loss:.4f} – acc {acc:.4f} – f1 {f1_score:.4f}"
                 )
             batch_id += 1
 
@@ -410,13 +439,16 @@ class CharLoadTFModel(BaseTrainableModel, metaclass=AutoSubRegistrationMeta):
             )
             val_recall = f1_report["weighted avg"]["recall"] if f1_report else np.NAN
             epoch_time = time.time() - start_time
+            loss, acc, f1_score = model_results[1], model_results[2], model_results[3]
             logger.info(
                 "\rEPOCH %d (%ds), loss: %f - acc: %f - f1_score %f -- "
                 "val_f1: %f - val_precision: %f - val_recall %f"
                 % (
                     self._epoch_id,
                     epoch_time,
-                    *model_results[1:],
+                    loss,
+                    acc,
+                    f1_score,
                     val_f1,
                     val_precision,
                     val_recall,

--- a/dataprofiler/labelers/data_labelers.py
+++ b/dataprofiler/labelers/data_labelers.py
@@ -127,12 +127,10 @@ class DataLabeler:
                 dirpath = os.path.join(
                     default_labeler_dir, data_labeler._default_model_loc
                 )
-            if force_construct_model:
+            else:
                 return TrainableDataLabeler(
                     dirpath, load_options, force_construct_model
                 )
-            else:
-                return TrainableDataLabeler(dirpath, load_options)
         return data_labeler(dirpath, load_options)
 
     @classmethod

--- a/dataprofiler/labelers/data_labelers.py
+++ b/dataprofiler/labelers/data_labelers.py
@@ -100,6 +100,7 @@ class DataLabeler:
         dirpath: str = None,
         load_options: dict = None,
         trainable: bool = False,
+        force_construct_model: bool = False,
     ) -> BaseDataLabeler:
         """
         Create structured and unstructured data labeler objects.
@@ -126,7 +127,12 @@ class DataLabeler:
                 dirpath = os.path.join(
                     default_labeler_dir, data_labeler._default_model_loc
                 )
-            return TrainableDataLabeler(dirpath, load_options)
+            if force_construct_model:
+                return TrainableDataLabeler(
+                    dirpath, load_options, force_construct_model
+                )
+            else:
+                return TrainableDataLabeler(dirpath, load_options)
         return data_labeler(dirpath, load_options)
 
     @classmethod

--- a/dataprofiler/labelers/data_labelers.py
+++ b/dataprofiler/labelers/data_labelers.py
@@ -127,10 +127,12 @@ class DataLabeler:
                 dirpath = os.path.join(
                     default_labeler_dir, data_labeler._default_model_loc
                 )
-            else:
+            if force_construct_model:
                 return TrainableDataLabeler(
                     dirpath, load_options, force_construct_model
                 )
+            else:
+                return TrainableDataLabeler(dirpath, load_options)
         return data_labeler(dirpath, load_options)
 
     @classmethod

--- a/dataprofiler/profilers/histogram_utils.py
+++ b/dataprofiler/profilers/histogram_utils.py
@@ -11,7 +11,7 @@ import operator
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
-from numpy.lib.histograms import (  # type: ignore[attr-defined]
+from numpy.lib._histograms_impl import (  # type: ignore[attr-defined]
     _get_outer_edges,
     _hist_bin_selectors,
     _unsigned_subtract,

--- a/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_integration_struct_data_labeler.py
@@ -29,7 +29,9 @@ class TestStructuredDataLabeler(unittest.TestCase):
             dp.labelers.base_data_labeler.default_labeler_dir,
             dp.labelers.StructuredDataLabeler._default_model_loc,
         )
-        default = dp.labelers.TrainableDataLabeler(dirpath=dirpath)
+        default = dp.labelers.TrainableDataLabeler(
+            dirpath=dirpath, force_construct_model=True
+        )
 
         # validate epoch id
         self.assertEqual(0, default.model._epoch_id)
@@ -295,7 +297,9 @@ class TestStructuredDataLabeler(unittest.TestCase):
         for dt in ["csv", "json", "parquet"]:
             data_obj = dp.Data(data=data, data_type=dt)
             label_obj = dp.Data(data=labels, data_type=dt)
-            labeler = dp.DataLabeler(labeler_type="structured", trainable=True)
+            labeler = dp.DataLabeler(
+                labeler_type="structured", trainable=True, force_construct_model=True
+            )
             self.assertIsNotNone(labeler.fit(x=data_obj, y=label_obj))
             self.assertIsNotNone(labeler.predict(data=data_obj))
 

--- a/dataprofiler/tests/labelers/test_integration_unstructured_data_labeler.py
+++ b/dataprofiler/tests/labelers/test_integration_unstructured_data_labeler.py
@@ -295,7 +295,9 @@ class TestUnstructuredDataLabeler(unittest.TestCase):
         label_str = entities(data_cells, label_cells)
         for dt in ["csv", "json", "parquet"]:
             data_obj = dp.Data(data=pd.DataFrame([data_str]), data_type=dt)
-            labeler = dp.DataLabeler(labeler_type="unstructured", trainable=True)
+            labeler = dp.DataLabeler(
+                labeler_type="unstructured", trainable=True, force_construct_model=True
+            )
             self.assertIsNotNone(labeler.fit(x=data_obj, y=[label_str]))
             self.assertIsNotNone(labeler.predict(data=data_obj))
 
@@ -312,13 +314,17 @@ class TestUnstructuredDataLabeler(unittest.TestCase):
         three_labels = [entities(d, l) for (d, l) in zipped]
         for dt in ["csv", "json", "parquet"]:
             data_obj = dp.Data(data=data_df, data_type=dt)
-            labeler = dp.DataLabeler(labeler_type="unstructured", trainable=True)
+            labeler = dp.DataLabeler(
+                labeler_type="unstructured", trainable=True, force_construct_model=True
+            )
             self.assertIsNotNone(labeler.fit(x=data_obj, y=three_labels))
             self.assertIsNotNone(labeler.predict(data=data_obj))
 
         # Test with text data object
         text_obj = dp.Data(data=data_str, data_type="text")
-        labeler = dp.DataLabeler(labeler_type="unstructured", trainable=True)
+        labeler = dp.DataLabeler(
+            labeler_type="unstructured", trainable=True, force_construct_model=True
+        )
         self.assertIsNotNone(labeler.fit(x=text_obj, y=[label_str]))
         self.assertIsNotNone(labeler.predict(data=text_obj))
 

--- a/dataprofiler/tests/profilers/test_categorical_column_profile.py
+++ b/dataprofiler/tests/profilers/test_categorical_column_profile.py
@@ -725,7 +725,7 @@ class TestCategoricalColumn(unittest.TestCase):
                 "chi2-test": {
                     "chi2-statistic": 82 / 35,
                     "deg_of_free": 2,
-                    "p-value": 0.3099238764710244,
+                    "p-value": 0.3099238764710245,
                 },
                 "psi": 0.0990210257942779,
             },

--- a/dataprofiler/tests/profilers/test_profile_builder.py
+++ b/dataprofiler/tests/profilers/test_profile_builder.py
@@ -2154,7 +2154,7 @@ class TestStructuredProfiler(unittest.TestCase):
         expected_chi2_test_dict = {
             "chi2-statistic": 2.342857142857143,
             "deg_of_free": 2,
-            "p-value": 0.3099238764710244,
+            "p-value": 0.3099238764710245,
         }
         self.assertDictEqual(
             expected_chi2_test_dict, diff["data_stats"][0]["statistics"]["chi2-test"]

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,7 +1,5 @@
 scikit-learn>=0.23.2
-keras<=3.4.0
+keras<=3.5.0
 rapidfuzz>=2.6.1
-tensorflow>=2.16.0; sys.platform != 'darwin'
-tensorflow>=2.16.0; sys_platform == 'darwin' and platform_machine != 'arm64'
-tensorflow-macos>=2.16.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow==2.19.0
 tqdm>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 h5py>=2.10.0
 wheel>=0.33.1
-numpy<2.0.0
+numpy>=2.0.0
 pandas>=1.1.2
 python-dateutil>=2.7.5
 pytz>=2020.1


### PR DESCRIPTION
This upgrades `numpy>2.0.0` so we can continue using it as a package in dquality.

To run tests locally, download the repo and run `make setup` and then `make test`. I found it easiest to do this inside a venv.

Changes:
- Ugrades Numpy
- Upgrades tensorflow from 2.16->2.19 (required by numpy)
- Updates the package name `numpy.lib.histograms` -> `numpy.lib._histograms_impl`(required by numpy)
- Updates to model behavior detailed below (required by tensorflow 2.19)

**Note:** The changes I make here are definitely a patch job. I think the best way to handle this would be to factor out a separate “training” model with only the softmax output, and point it at the same layers as the inference model. This would require significant effort on our part to understand and rearchitect their models and is probably not worth the effort. Also there is a ton of duplicate logic in here that I am choosing to leave alone.

In TF-Keras 2.19, any model with multiple outputs must be trained with a ground-truth `y_true` for every output. for example, their Character-Level CNN defines three outputs:

1. **Softmax** logits (`(batch, seq_len, num_labels)`) — the only one we actually train on  
2. **Argmax** indices (`(batch, seq_len)`) — downstream inference  
3. **Thresholded argmax** indices (`(batch, seq_len)`) — downstream inference  

We only care about the softmax for training, so:
- **Loss setup**  
  ```python
  self._model.compile(
      loss_weights={
        'softmax_output':   1.0,
        'argmax':           0.0, 
        'thresh_argmax':    0.0,
      },
      loss={
        'softmax_output': 'categorical_crossentropy',
        'argmax':         'mean_squared_error',
        'thresh_argmax':  'mean_squared_error',
      },
      …
  )
We assign a dummy loss (mean_squared_error) to the two inference outputs but zero their loss_weight, so they never affect gradients. Then at training time we supply dummy vectors as the `y` training vectors for the inference outputs to keep Keras happy.

Some tests rely on precompiled and saved versions of the models, and they have to be reconstructed in order for the tests to work after the changes I have made. I created the ability to optionally "force construct" models at load time to get around this. I would be better if these files were replaced, I don't feel super comfortable doing that without more information about how they were created.

There are 2 tests that still fail locally that I am choosing to ignore
1. testing that the seed is set to a default of `None`, but it's intentionally set to 0 when tests are run locally, so it fails.
2. The default verbosity of logs is `Warning` but should be `Info`, I think this is being set somewhere in testing and I'm not concerned about it.

