### PR TITLE
Allow tensorflow versions 2.X.X greater than 2.19.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,9 +84,7 @@ repos:
             scikit-learn>=0.23.2,
             'keras>=2.4.3,<=3.4.0',
             rapidfuzz>=2.6.1,
-            "tensorflow>=2.6.4,<2.15.0; sys.platform != 'darwin'",
-            "tensorflow>=2.6.4,<2.15.0; sys_platform == 'darwin' and platform_machine != 'arm64'",
-            "tensorflow-macos>=2.6.4,<2.15.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
+            'tensorflow>=2.19.0,<3.0.0',
             tqdm>=4.0.0,
 
             # requirements-reports.txt

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,5 +1,5 @@
 scikit-learn>=0.23.2
 keras<=3.5.0
 rapidfuzz>=2.6.1
-tensorflow==2.19.0
+tensorflow>=2.19.0,<3.0.0
 tqdm>=4.0.0


### PR DESCRIPTION
# Why?

To support python 3.13, we need to allow tensorflow 2.20.0 or greater. Currently DataProfiler is pinned to 2.19.0 but it doesn't really need to be pinned so tightly.

To unblock the python 3.13, let's allow versions of tensorflow greater than 2.19.0 but less than 3. This gives us some room to grow / upgrade beyond what's needed for python 3.13